### PR TITLE
Omnibus: fix lexer hang, bind_filters serialization, top-level dup keys + harden the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.js
+!jest.config.js
 .vscode
 *.code-workspace
 *.out

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/test/*.ts'],
+  // Tests import sources as "../src/foo.js"; strip the .js so ts-jest resolves the .ts.
+  moduleNameMapper: { '^(\\.{1,2}/.*)\\.js$': '$1' },
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "out/index.js",
   "types": "out/index.d.ts",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "type-check": "tsc --noEmit"
   },
   "repository": {
     "type": "git",
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@types/jest": "^25.2.3",
     "jest": "^26.0.1",
-    "ts-jest": "^26.0.0"
+    "ts-jest": "^26.0.0",
+    "typescript": "^4.9.5"
   }
 }

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -137,6 +137,7 @@ export class Lexer {
                 return true
             }
         }
+        return false
     }
 
     scan_expression_block(): object {
@@ -145,13 +146,13 @@ export class Lexer {
         Looker usually adds an extra space before the `;;` terminal. */
 
         let chars = ""
-        while (this.peek_multiple(2) != ";;") {
+        while (this.peek_multiple(2) != ";;" && this.peek() != "\0") {
             if (this.peek() == "\n") {
                 this.line_number += 1
             }
             chars += this.consume()
         }
-        chars = chars.trim() // TODO: this was an rtrim... could it cause a bug?
+        chars = chars.trim()
         return new tokens.ExpressionBlockToken(chars, this.line_number)
     }
 
@@ -180,12 +181,9 @@ export class Lexer {
         method only scans for the trailing quote to indicate the end of the token. */
 
         let chars = ""
-        while (true) {
+        while (this.peek() != '"' && this.peek() != "\0") {
             let ch = this.peek()
-            if (ch == '"') {
-                break;
-            }
-            else if (ch == "\\") {
+            if (ch == "\\") {
                 chars += this.consume()  // Extra consume to skip the escaped character
             }
             else if (ch == "\n") {
@@ -193,7 +191,11 @@ export class Lexer {
             }
             chars += this.consume()
         }
-        this.advance()
+        // Leave the "\0" sentinel in place on an unterminated literal so scan()
+        // still terminates and the parser raises a SyntaxError instead of hanging.
+        if (this.peek() == '"') {
+            this.advance()
+        }
         return new tokens.QuotedLiteralToken(chars, this.line_number)
     }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,15 +3,6 @@
 import * as tokens from "./tokens"
 import { PLURAL_KEYS } from "./keys"
 
-declare global {
-    interface String {
-        repeat(c: number): string;
-    }
-    interface ObjectConstructor {
-        assign(...objects: Object[]): Object;
-    }
-}
-
 // Delimiter character used during logging to show the depth of nesting
 const DELIMITER: string = ". "
 const DEBUG = false
@@ -42,10 +33,15 @@ export class Parser {
         literal ← [0-9A-Za-z_]+
     */
 
+    // Names of every registered token type, computed once instead of rescanning
+    // the registry on every check() call.
+    static valid_token_names = new Set(tokens.tokenTypes.map((t: any) => t.name))
+
     tokens: object
     index: number
     progress: number
     depth: number
+    container_depth: number
     log_debug: boolean
 
     constructor(stream: object) {
@@ -65,6 +61,7 @@ export class Parser {
         this.index = 0
         this.progress = 0
         this.depth = -1
+        this.container_depth = -1
         this.log_debug = DEBUG
     }
 
@@ -126,19 +123,10 @@ export class Parser {
             }
 
             // Determine if input_tokens are valid Tokens
-            let valid_tokens: number = 0
-            for (let type_key in tokens.tokenTypes) {
-                let token_type = tokens.tokenTypes[type_key];
-                for (let token_key in input_tokens) {
-                    let token = input_tokens[token_key]
-                    if (token_type.name == token.name) {
-                        valid_tokens++
-                        break
-                    }
+            for (let token_key in input_tokens) {
+                if (!Parser.valid_token_names.has(input_tokens[token_key].name)) {
+                    throw new TypeError("Input contained invalid token types.")
                 }
-            }
-            if (valid_tokens != input_tokens.length) {
-                throw new TypeError("Input contained invalid token types.")
             }
 
             // Determine if the current token is one of the desired input_tokens
@@ -193,7 +181,7 @@ export class Parser {
                 }
             }
             else if (Object.keys(target).indexOf(key) != -1) {
-                if (this.depth == 0) {
+                if (this.container_depth == 0) {
                     console.log("Multiple declarations of top-level key " + key + " found. Using the last-declared value.")
                     target[key] = update[key]
                 }
@@ -214,51 +202,52 @@ export class Parser {
         Grammar:
             expression ← (block / pair / list)* */
         
-        let mark = this.index
         this.depth += 1
+        // container_depth tracks nesting of containers only, restored on every
+        // exit, so update_tree can tell a top-level key (last-wins) from a
+        // nested one (error). depth is left for debug-log indentation.
+        this.container_depth += 1
+        try {
+            if (this.log_debug) {
+                let grammar = "[expression] = (block / pair / list)*"
+                console.log(DELIMITER.repeat(this.get_depth()) + "Try to parse " + grammar)
+            }
+            let expression = {}
+            if (this.check(tokens.StreamStartToken)) {
+                this.advance()
+            }
+            while (!this.check(tokens.StreamEndToken, tokens.BlockEndToken)) {
 
-        if (this.log_debug) {
-            let grammar = "[expression] = (block / pair / list)*"
-            console.log(DELIMITER.repeat(this.get_depth()) + "Try to parse " + grammar)
-        }
-        let expression = {}
-        if (this.check(tokens.StreamStartToken)) {
-            this.advance()
-        }
-        while (!this.check(tokens.StreamEndToken, tokens.BlockEndToken)) {
+                let block = this.parse_block()
+                if (block) {
+                    this.update_tree(expression, block)
+                    continue
+                }
 
-            let block = this.parse_block()
-            if (block) {
-                this.update_tree(expression, block)
-                continue
+                let pair = this.parse_pair()
+                if (pair) {
+                    this.update_tree(expression, pair)
+                    continue
+                }
+
+                let list = this.parse_list()
+                if (list) {
+                    expression = Object.assign(expression, list)
+                    continue
+                }
+
+                let token = this.tokens[this.progress]
+                throw new SyntaxError("Unable to find a matching expression for " + token.id + " on line " + token.line_number)
             }
 
-            let pair = this.parse_pair()
-            if (pair) {
-                this.update_tree(expression, pair)
-                continue
+            if (this.log_debug) {
+                console.log(DELIMITER.repeat(this.get_depth()) + "Successfully parsed expression.")
             }
 
-            let list = this.parse_list()
-            if (list) {
-                expression = Object.assign(expression, list)
-                continue
-            }
-
-            let token = this.tokens[this.progress]
-            throw new SyntaxError("Unable to find a matching expression for " + token.id + " on line " + token.line_number)
+            return expression
+        } finally {
+            this.container_depth -= 1
         }
-
-        if (this.log_debug) {
-            console.log(DELIMITER.repeat(this.get_depth()) + "Successfully parsed expression.")
-        }
-
-        if (!expression) {
-            this.depth -= 1
-            this.backtrack(mark)
-        }
-
-        return expression
     }
 
     parse_block() {
@@ -512,7 +501,7 @@ export class Parser {
 
         if (this.check(tokens.ListEndToken)) {
             this.advance()
-            let list = []
+            let list = {}
             list[key] = csv
             if (this.log_debug) {
                 console.log(DELIMITER.repeat(this.get_depth()) + "Successfully parsed a list.")
@@ -549,7 +538,7 @@ export class Parser {
             let grammar = '[csv] = (literal / quoted_literal) ("," (literal / quoted_literal))* ","?'
             console.log(DELIMITER.repeat(this.get_depth()) + "Try to parse " + grammar)
         }
-        let values = []
+        let values: any[] = []
 
         if (this.check(tokens.LiteralToken, tokens.QuotedLiteralToken)) {
             values.push(this.consume_token_value())

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -6,12 +6,6 @@ import { EXPR_BLOCK_KEYS
        , KEYS_FOR_SETS
        , QUOTED_LITERAL_KEYS } from "./keys"
 
-declare global {
-    interface Object {
-        entries<X extends string,Y>(o: { [key in X]: Y }): [X, Y][];
-    }
-}
-
 export class Serializer {
     /* Serializes a Javascript object into a LookML string.
     Review the grammar specified for the Parser class to understand how LookML
@@ -127,7 +121,7 @@ export class Serializer {
             key = key.replace(/s$/, '')
         }
         let i: number = 0
-        for (let [idx, val] of values.entries()) {
+        for (let val of values) {
             if (i > 0) {
                 yield "\n"
             }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -158,6 +158,12 @@ export class Serializer {
             else if (KEYS_FOR_SETS.indexOf(key) != -1) {
                 yield* this.write_set(key, value)
             }
+            else if (Array.isArray(value)) {
+                // Anonymous-block plural keys (e.g. bind_filters): emit each
+                // element as its own block. Falling through to the block branch
+                // below serialized them as `bind_filters: { undefined: {...} }`.
+                yield* this.expand_list(key, value)
+            }
             else {
                 let name: string = ""
                 if (KEYS_WITH_NAME_FIELDS.indexOf(key) != -1 || Object.keys(value).indexOf("name") == -1) {
@@ -167,10 +173,7 @@ export class Serializer {
                     name = value.name
                     delete(value.name)
                 }
-                if (!isNaN(Number(key))) {
-                    key = value.name
-                }
-                
+
                 let block: Generator<string> = this.write_block(key, value, name)
                 let output: string = ""
                 while (true) {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,6 +1,6 @@
 // Tokens used by the lexer to tokenize LookML.
 
-export const tokenTypes = [];
+export const tokenTypes: Function[] = [];
 
 export function register_token() {
     return function(target: Function) {

--- a/test/malformed.ts
+++ b/test/malformed.ts
@@ -1,0 +1,19 @@
+import { lkml } from '../src/lkml.js'
+const LookML = new lkml();
+
+// Regression tests: unterminated quoted literals / expression blocks used to
+// hang the lexer (it ran off the end of the string); they must now throw.
+
+test('unterminated quoted literal throws instead of hanging', () => {
+  expect(() => LookML.load(`view: v{ label: "unterminated }`)).toThrow();
+});
+
+test('unterminated expression block throws instead of hanging', () => {
+  expect(() => LookML.load(`view: v{ sql: SELECT 1`)).toThrow();
+});
+
+test('well-formed quoted literal and expression block still parse', () => {
+  let out: any = LookML.load(`view: v{ label: "ok" sql: \${TABLE}.id ;; }`);
+  expect(out.views[0].label).toBe('ok');
+  expect(out.views[0].sql).toBe('${TABLE}.id');
+});

--- a/test/top_level_duplicate.ts
+++ b/test/top_level_duplicate.ts
@@ -1,0 +1,28 @@
+import { lkml } from '../src/lkml.js'
+const LookML = new lkml();
+
+// A duplicate top-level non-plural key takes last-wins, even after an
+// intervening nested block. Regression for container-depth bookkeeping that
+// previously left depth elevated, making the second `connection` throw.
+
+test('top-level duplicate non-plural key keeps the last value', () => {
+  const src = `connection: "a"
+
+view: v{
+  dimension: d{
+    sql: \${TABLE}.x ;;
+  }
+}
+
+connection: "b"`;
+  const out: any = LookML.load(src);
+  expect(out.connection).toBe('b');
+});
+
+test('nested duplicate non-plural key still errors', () => {
+  const src = `view: v{
+  sql_table_name: a ;;
+  sql_table_name: b ;;
+}`;
+  expect(() => LookML.load(src)).toThrow();
+});

--- a/test/view_with_all_fields.ts
+++ b/test/view_with_all_fields.ts
@@ -46,10 +46,8 @@ view: view_name{
   derived_table: {
     explore_source: explore_name{
       bind_filters: {
-        undefined: {
-          from_field: field_name
-          to_field: field_name
-        }
+        from_field: field_name
+        to_field: field_name
       }
 
       column: column_name{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,16 @@
         "lib": [
             "es2020",
             "dom",
-        ]
+        ],
+        "skipLibCheck": true,
+        "strictNullChecks": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
+        "alwaysStrict": true,
+        "forceConsistentCasingInFileNames": true
     },
     "include": [
         "src/**/*",


### PR DESCRIPTION
## Purpose
Fix the correctness bugs and rough edges in the parser/serializer (most surfaced while comparing this port against a fresh Go port of the same `joshtemple/lkml`), and make the test suite actually runnable.

## Bug fixes

**1. Lexer hangs on unterminated input.** An unterminated quoted literal (`label: "foo`) or expression block (`sql: SELECT 1` with no `;;`) ran `charAt()` off the end of the input forever — in JS `charAt()` past the end returns `""` and never throws, so the scan loops never terminated and `load()` spun indefinitely. Added an end-of-stream (`"\0"`) guard to `scan_quoted_literal` and `scan_expression_block` (the sentinel is left in place so the parser raises a `SyntaxError`), plus the missing `return false` in `check_for_expression_block`.

**2. `bind_filters` serialized as `{ undefined: { ... } }`.** It parsed correctly to a list of anonymous blocks, but the serializer excluded it from `expand_list`, fell through to the block branch, and a numeric array-index hack set `key = value.name = undefined`. Array-valued keys now route through `expand_list`; the dead hack is gone. The `view_with_all_fields` fixture had frozen the buggy output as "expected" — corrected to a real anonymous block.

**3. Top-level duplicate non-plural key wrongly threw.** `depth` was incremented on entry to every `parse_*` method but only restored on failure, so it never returned to 0 once anything nested. `update_tree`'s top-level "last-wins" rule keyed on `depth == 0`, so a duplicate top-level key after any block threw instead. Now tracked via a separate `container_depth`, restored on every `parse_expression` exit with `try/finally`.

## Hardening / cleanup
- `check()` rescanned the entire token registry on every call to validate its arguments — precompute the valid-name set once.
- `parse_list` built an `Array` but used it as a string-keyed map → `{}`.
- Dropped redundant global augmentations (`String.repeat` / `Object.assign` / `Object.entries`, all in the `es2020` lib target).
- Enabled a safe strict subset in `tsconfig` (`strictNullChecks`, `noImplicitReturns`, `noUnused*`, `noFallthroughCasesInSwitch`, `skipLibCheck`, …) and fixed the resulting errors.

## Test infrastructure
The suite previously matched nothing under a bare `jest` invocation. Added a ts-jest config + `testMatch`, a `type-check` script, and declared the `typescript` devDependency. New tests: `test/malformed.ts` (unterminated inputs — both timed out before the lexer fix, verified exit 124) and `test/top_level_duplicate.ts`. **All 6 suites / 9 tests pass; `tsc --noEmit` is clean.**